### PR TITLE
Fix to Import of Projection Variables

### DIFF
--- a/R/PCAFuturo_TMLA.R
+++ b/R/PCAFuturo_TMLA.R
@@ -58,7 +58,7 @@ PCAFuturo<-function(Env,
   DirP <- as.list(DirP)
   ProjEX <- lapply(DirP, function(x) unique(file_ext(list.files(x))))
   form <- c('bil','asc','txt','tif')
-  ProjEX <- ProjEX[ProjEX%in%form]
+  ProjEX <- unique(unlist(ProjEX)[unlist(ProjEX)%in%form])
 
   if(any(ProjEX %in% c('asc', 'bil', 'tif'))){
     ProjT<-lapply(DirP, function(x) brick(stack(file.path(x,list.files(x,paste0('\\.',ProjEX,'$'))))))


### PR DESCRIPTION
Fix to an error caused by multiple file formats within the folders of projection variables