### PR TITLE
Change cores=1 so that it doesn't create parallel clusters

### DIFF
--- a/R/BandsPartition_TMLA.R
+++ b/R/BandsPartition_TMLA.R
@@ -18,16 +18,7 @@ BandsPartition_TMLA <- function(evnVariables = NULL,
 
   #Development
   #Start Cluster
-  if (Sys.getenv("RSTUDIO") == "1" &&
-      !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
-      Sys.info()["sysname"] == "Darwin" &&
-      as.numeric(gsub('[.]', '', getRversion())) >= 360) {
-    cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
-  }else{
-    cl <- parallel::makeCluster(cores,outfile="")
-  }
-  doParallel::registerDoParallel(cl)
-
+  cl <- start_cluster(cores)
 
   #Separate data by groups
   RecordsData <-
@@ -583,6 +574,6 @@ BandsPartition_TMLA <- function(evnVariables = NULL,
     sep = "\t",
     row.names = F
   )
-  parallel::stopCluster(cl)
+  stop_cluster(cl)
   return(FinalResult)
 }

--- a/R/BlockPartition_TMLA.R
+++ b/R/BlockPartition_TMLA.R
@@ -42,15 +42,7 @@ BlockPartition_TMLA <- function(evnVariables = NULL,
   # BestGridList <- rep(list(NULL),length(RecordsData))
 
   #Start Cluster
-  if (Sys.getenv("RSTUDIO") == "1" &&
-      !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
-      Sys.info()["sysname"] == "Darwin" &&
-      as.numeric(gsub('[.]', '', getRversion())) >= 360) {
-        cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
-      }else{
-        cl <- parallel::makeCluster(cores,outfile="")
-      }
-      doParallel::registerDoParallel(cl)
+  cl <- start_cluster(cores)
 
   # LOOP----
   results <-
@@ -598,7 +590,8 @@ BlockPartition_TMLA <- function(evnVariables = NULL,
       return(out)
     }
 
-  parallel::stopCluster(cl)
+  stop_cluster(cl)
+
   FinalResult <- dplyr::bind_rows(lapply(results, function(x) x[[1]]))
   FinalInfoGrid <- dplyr::bind_rows(lapply(results, function(x) x[[2]]))
 

--- a/R/Ensemble_TMLA.R
+++ b/R/Ensemble_TMLA.R
@@ -11,15 +11,7 @@ Ensemble_TMLA <- function(DirR,
                           cores,
                           ensemble_metric = NULL) {
   #Start Cluster----
-  if (Sys.getenv("RSTUDIO") == "1" &&
-      !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
-      Sys.info()["sysname"] == "Darwin" &&
-      as.numeric(gsub('[.]', '', getRversion())) >= 360) {
-        cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
-      }else{
-        cl <- parallel::makeCluster(cores,outfile="")
-      }
-  doParallel::registerDoParallel(cl)
+  cl <- start_cluster(cores)
 
   #Create Folders----
   DirENS <- paste(DirR, "Ensemble", sep = "/")
@@ -629,5 +621,5 @@ Ensemble_TMLA <- function(DirR,
     col.names = T,
     row.names = F
   )
-  parallel::stopCluster(cl)
+  stop_cluster(cl)
 }

--- a/R/FitENM_Parallel_TMLA.R
+++ b/R/FitENM_Parallel_TMLA.R
@@ -26,17 +26,8 @@ FitENM_TMLA_Parallel <- function(RecordsData,
   Ti <- Sys.time()
   options(warn = -1)
 
-  #Start Cluster
-  # temporary parallel package debug for macOS systems
-  if (Sys.getenv("RSTUDIO") == "1" &&
-      !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
-      Sys.info()["sysname"] == "Darwin" &&
-      as.numeric(gsub('[.]', '', getRversion())) >= 360) {
-        cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
-      }else{
-        cl <- parallel::makeCluster(cores,outfile="")
-      }
-  doParallel::registerDoParallel(cl)
+  #Start Cluster if necessary
+  cl <- start_cluster(cores)
 
   # Directory to save----
   folders <- paste(DirSave,"Algorithm",Algorithm,sep="/")
@@ -4058,5 +4049,5 @@ InfoModeling <- list(c("########################################################
   lapply(InfoModeling, write,
          paste(DirSave, "/InfoModeling.txt", sep=""), append=TRUE,
          ncolumns=20, sep='\t')
-  parallel::stopCluster(cl)
+  stop_cluster(cl)
 }

--- a/R/M_delimited_TMLA.R
+++ b/R/M_delimited_TMLA.R
@@ -76,15 +76,7 @@ M_delimited <- function(var,
       return(x)
     })
 
-    if (Sys.getenv("RSTUDIO") == "1" &&
-        !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
-        Sys.info()["sysname"] == "Darwin" &&
-        as.numeric(gsub('[.]', '', getRversion())) >= 360) {
-          cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
-        }else{
-          cl <- parallel::makeCluster(cores,outfile="")
-        }
-    doParallel::registerDoParallel(cl)
+    cl <- start_cluster(cores)
     foreach(i = 1:length(M_list),
             .packages = c("raster")) %dopar% {
               if (Buffer_Opt == 2) {
@@ -105,7 +97,7 @@ M_delimited <- function(var,
                                   format = "GTiff",
                                   overwrite = T)
             }
-    parallel::stopCluster(cl)
+    stop_cluster(cl)
   }
 
   if (method == 'MASK') {
@@ -136,15 +128,7 @@ M_delimited <- function(var,
       x <- x[x != 0]
     })
 
-    if (Sys.getenv("RSTUDIO") == "1" &&
-        !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
-        Sys.info()["sysname"] == "Darwin" &&
-        as.numeric(gsub('[.]', '', getRversion())) >= 360) {
-          cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
-        }else{
-          cl <- parallel::makeCluster(cores,outfile="")
-        }
-    doParallel::registerDoParallel(cl)
+    cl <- start_cluster(cores)
     foreach(i = 1:length(sp.Ecoregions),
             .packages = c("raster")) %dopar% {
               EcoregionSp <- EcoregionsFile
@@ -159,7 +143,7 @@ M_delimited <- function(var,
                 overwrite = T
               )
             }
-    parallel::stopCluster(cl)
+    stop_cluster(cl)
   }
 
   if (method == 'USER-DEFINED') {

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -1,18 +1,22 @@
 
 start_cluster <- function(cores) {
   cl <- NULL
-  if (Sys.getenv("RSTUDIO") == "1" &&
-      !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
-      Sys.info()["sysname"] == "Darwin" &&
-      as.numeric(gsub('[.]', '', getRversion())) >= 360) {
-    cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
-  }else{
-    cl <- parallel::makeCluster(cores,outfile="")
+  if (cores > 1) {
+    if (Sys.getenv("RSTUDIO") == "1" &&
+        !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
+        Sys.info()["sysname"] == "Darwin" &&
+        as.numeric(gsub('[.]', '', getRversion())) >= 360) {
+      cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
+    }else{
+      cl <- parallel::makeCluster(cores,outfile="")
+    }
+    doParallel::registerDoParallel(cl)
   }
-  doParallel::registerDoParallel(cl)
   return(cl)
 }
 
 stop_cluster <- function(cluster) {
-  parallel::stopCluster(cluster)
+  if (!is.null(cluster)) {
+    parallel::stopCluster(cluster)
+  }
 }

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -1,0 +1,18 @@
+
+start_cluster <- function(cores) {
+  cl <- NULL
+  if (Sys.getenv("RSTUDIO") == "1" &&
+      !nzchar(Sys.getenv("RSTUDIO_TERM")) &&
+      Sys.info()["sysname"] == "Darwin" &&
+      as.numeric(gsub('[.]', '', getRversion())) >= 360) {
+    cl <- parallel::makeCluster(cores,outfile="", setup_strategy = "sequential")
+  }else{
+    cl <- parallel::makeCluster(cores,outfile="")
+  }
+  doParallel::registerDoParallel(cl)
+  return(cl)
+}
+
+stop_cluster <- function(cluster) {
+  parallel::stopCluster(cluster)
+}


### PR DESCRIPTION
This makes it easier to debug problems. If you set cores=1 with current master, you still have everything run on a cluster (with 1 core) which means error messages are often obfuscated to the effect of "no connection" type errors.

This just turns off the creation (and destruction) of the cluster, allowing everything to run as per usual. Errors then get reported directly.

NOTE: There is an additional `parallel::makeCluster()` command in `Ensemble_TMLA.R` that appears to be incorrect. I have no idea what it is supposed to be doing, so have not changed this one. If you can direct me as to it's use, I'm happy to incorporate into this framework :)